### PR TITLE
Initialize src-based project structure with CLI and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ml-experiment-tracker"
+version = "0.1.0"
+description = "ML Experiment Tracker"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-q"

--- a/src/mltracker/__init__.py
+++ b/src/mltracker/__init__.py
@@ -1,0 +1,4 @@
+"""ML Experiment Tracker package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -1,0 +1,10 @@
+"""Command-line interface for ML Experiment Tracker."""
+
+
+def main() -> None:
+    """Run the CLI entrypoint."""
+    print("ML Experiment Tracker")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,7 @@
+from mltracker.cli import main
+
+
+def test_main_prints_banner(capsys):
+    main()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "ML Experiment Tracker"


### PR DESCRIPTION
### Motivation
- Provide an initial `src/`-layout Python package to serve as the base for the ML Experiment Tracker project.
- Include a minimal CLI entrypoint to verify runtime behavior and to serve as a starting point for user-facing functionality.
- Ensure tests can import the package cleanly when using the `src` layout by configuring the test environment.

### Description
- Added `pyproject.toml` with basic project metadata and `pytest` configuration that sets `pythonpath = ["src"]` for imports.
- Created package `src/mltracker` with `__init__.py` exposing `__version__`.
- Added CLI module `src/mltracker/cli.py` with a `main()` function that prints "ML Experiment Tracker" and a `__main__` guard.
- Added `tests/test_cli.py` with a test that calls `main()` and asserts the printed output matches the expected banner.

### Testing
- Ran `pytest` and the test suite completed successfully with `1 passed`.
- The `pythonpath` adjustment in `pyproject.toml` allowed tests to import `mltracker` from the `src` layout without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24fd51e088330a356d68bec2fab15)