### PR TITLE
Add GitHub Actions CI workflow for Python tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,28 @@
+name: Python Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        env:
+          PYTHONPATH: src
+        run: pytest


### PR DESCRIPTION
### Motivation
- Run the test suite automatically on both `push` and `pull_request` to catch regressions early.
- Ensure the repository's `src`-layout imports work reliably in CI by configuring the test environment accordingly.

### Description
- Add `.github/workflows/python-tests.yml` which checks out the repository, sets up Python `3.12` via `actions/setup-python@v5`, installs `pytest`, and runs `pytest`.
- The test step sets `PYTHONPATH: src` so tests import from the `src` layout correctly.
- No source changes were necessary and `pyproject.toml` already configures pytest with `pythonpath = ["src"]`.

### Testing
- Ran `pytest` locally and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e5986d748330b22cacf955029bf0)