### PR TITLE
Add create-run command to CLI with local JSON run storage

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -1,9 +1,55 @@
 """Command-line interface for ML Experiment Tracker."""
 
+from __future__ import annotations
 
-def main() -> None:
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+RUNS_DIR = Path("runs")
+
+
+def create_run(name: str) -> Path:
+    """Create a run JSON file in the local runs directory."""
+    RUNS_DIR.mkdir(exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    safe_name = name.strip().replace(" ", "_")
+    run_file = RUNS_DIR / f"{timestamp.replace(':', '-')}_{safe_name}.json"
+
+    payload = {
+        "name": name,
+        "timestamp": timestamp,
+        "metadata": {},
+    }
+
+    run_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return run_file
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(prog="mltracker")
+    subparsers = parser.add_subparsers(dest="command")
+
+    create_run_parser = subparsers.add_parser("create-run", help="Create an experiment run")
+    create_run_parser.add_argument("--name", required=True, help="Run name")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
     """Run the CLI entrypoint."""
-    print("ML Experiment Tracker")
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "create-run":
+        run_path = create_run(args.name)
+        print(f"Created run: {run_path}")
+    else:
+        print("ML Experiment Tracker")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,30 @@
+import json
+from pathlib import Path
+
 from mltracker.cli import main
 
 
 def test_main_prints_banner(capsys):
-    main()
+    main([])
     captured = capsys.readouterr()
     assert captured.out.strip() == "ML Experiment Tracker"
+
+
+def test_create_run_creates_json_file(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "baseline"])
+
+    runs_dir = tmp_path / "runs"
+    assert runs_dir.exists()
+
+    run_files = list(runs_dir.glob("*.json"))
+    assert len(run_files) == 1
+
+    payload = json.loads(run_files[0].read_text(encoding="utf-8"))
+    assert payload["name"] == "baseline"
+    assert isinstance(payload["timestamp"], str)
+    assert payload["metadata"] == {}
+
+    captured = capsys.readouterr()
+    assert "Created run:" in captured.out


### PR DESCRIPTION
### Motivation
- Provide a simple CLI mechanism to create and persist experiment runs locally as JSON files for lightweight tracking.
- Keep the implementation minimal and easily testable while including timestamped metadata in each run file.

### Description
- Add a `create-run` subcommand with a required `--name` argument to `src/mltracker/cli.py` using `argparse`.
- Implement `create_run` to create a local `runs/` directory (if missing), generate an ISO timestamp, and write a per-run JSON file containing `name`, `timestamp`, and an empty `metadata` object.
- Route the new subcommand in `main` and print the created run file path, and add `tests/test_cli.py` coverage for the new behavior; changed files are `src/mltracker/cli.py` and `tests/test_cli.py`.
- Closes #3

### Testing
- Ran `pytest`, which completed successfully with `2 passed` and exit code 0.
- The new test `test_create_run_creates_json_file` verifies that the `runs/` directory is created, exactly one JSON run file is written, the JSON contains the expected `name`, `timestamp`, and `metadata`, and the CLI prints the created path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2eaa6a354833089be9b03b07b94a4)