### PR TITLE
Ignore generated experiment runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Generated experiment runs
+runs/


### PR DESCRIPTION
### Motivation
- Prevent generated experiment run artifacts from being tracked by Git by adding a top-level ignore rule for `runs/`.

### Description
- Added a short comment and `runs/` entry to `.gitignore` and did not modify any other files; this PR also includes the statement `Closes #4`.

### Testing
- Verified that only `.gitignore` was changed with `git status --short`, committed the change with `git add .gitignore && git commit -m "Ignore generated experiment runs"`, and confirmed the new ignore lines via `nl -ba .gitignore | tail -n 10`, and all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ed88da648330ae15337fe48d6b26)