### PR TITLE
Fix .gitignore runs rule to top-level only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,4 +218,4 @@ __marimo__/
 .streamlit/secrets.toml
 
 # Generated experiment runs
-runs/
+/runs/


### PR DESCRIPTION
### Motivation
- Ensure only the repository top-level `runs` directory is ignored by changing the `.gitignore` rule from `runs/` (which matches any directory named `runs`) to `/runs/` (which matches only the top-level directory).

### Description
- Replaced `runs/` with `/runs/` in `./.gitignore` and made no other modifications; Closes #<issue-number>.

### Testing
- Verified the update with a pattern search and file diff which confirmed a single-line replacement (`runs/` → `/runs/`) and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f0cd07c4833093db79666e4fa9ba)