### PR TITLE
Sanitize run names to avoid unsafe and nested run file paths

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -11,12 +12,19 @@ from pathlib import Path
 RUNS_DIR = Path("runs")
 
 
+def sanitize_run_name(name: str) -> str:
+    """Sanitize a run name so it is safe to use as part of a filename."""
+    normalized = name.strip().replace(" ", "_")
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", normalized)
+    return safe_name or "run"
+
+
 def create_run(name: str) -> Path:
     """Create a run JSON file in the local runs directory."""
     RUNS_DIR.mkdir(exist_ok=True)
 
     timestamp = datetime.now(timezone.utc).isoformat()
-    safe_name = name.strip().replace(" ", "_")
+    safe_name = sanitize_run_name(name)
     run_file = RUNS_DIR / f"{timestamp.replace(':', '-')}_{safe_name}.json"
 
     payload = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,3 +28,30 @@ def test_create_run_creates_json_file(tmp_path, capsys, monkeypatch):
 
     captured = capsys.readouterr()
     assert "Created run:" in captured.out
+
+
+def test_create_run_sanitizes_slashes_in_filename(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "model/v1"])
+
+    run_files = list((tmp_path / "runs").glob("*.json"))
+    assert len(run_files) == 1
+    assert "model_v1" in run_files[0].name
+
+    payload = json.loads(run_files[0].read_text(encoding="utf-8"))
+    assert payload["name"] == "model/v1"
+
+
+def test_create_run_prevents_nested_path_creation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "team/model:v1?best"])
+
+    runs_dir = tmp_path / "runs"
+    assert runs_dir.exists()
+    assert not (runs_dir / "team").exists()
+
+    run_files = list(runs_dir.glob("*.json"))
+    assert len(run_files) == 1
+    assert "team_model_v1_best" in run_files[0].name


### PR DESCRIPTION
### Motivation
- Run names may contain slashes or other unsafe filename characters which can create nested paths or invalid filenames when used directly in run file names.
- The intent is to ensure run files are always written under the `runs/` directory with safe filenames while preserving the original run name in stored metadata.

### Description
- Add a new `sanitize_run_name` helper that normalizes run names and replaces any character not in `A-Za-z0-9._-` with an underscore. 
- Use `sanitize_run_name` when constructing the JSON run file path so unsafe characters (including `/`) become underscores and nested paths are not created. 
- Preserve the original run name in the JSON payload by keeping `"name": name` unchanged. 
- Add tests `test_create_run_sanitizes_slashes_in_filename` and `test_create_run_prevents_nested_path_creation` to validate safe filename creation and prevention of nested directories; modified files: `src/mltracker/cli.py` and `tests/test_cli.py`.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (4 passed). 

Closes #5

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f2e940e8833094452f71ca8c1314)