### PR TITLE
Add log-metric CLI command to update run metrics

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -37,6 +37,22 @@ def create_run(name: str) -> Path:
     return run_file
 
 
+def log_metric(run_file: str, name: str, value: float) -> Path:
+    """Log a metric value to an existing run JSON file."""
+    run_path = Path(run_file)
+    payload = json.loads(run_path.read_text(encoding="utf-8"))
+
+    metrics = payload.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    metrics[name] = float(value)
+    payload["metrics"] = metrics
+
+    run_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return run_path
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
     parser = argparse.ArgumentParser(prog="mltracker")
@@ -44,6 +60,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     create_run_parser = subparsers.add_parser("create-run", help="Create an experiment run")
     create_run_parser.add_argument("--name", required=True, help="Run name")
+
+    log_metric_parser = subparsers.add_parser("log-metric", help="Log a metric to a run")
+    log_metric_parser.add_argument("--run-file", required=True, help="Path to run JSON file")
+    log_metric_parser.add_argument("--name", required=True, help="Metric name")
+    log_metric_parser.add_argument("--value", required=True, type=float, help="Metric value")
 
     return parser
 
@@ -56,6 +77,9 @@ def main(argv: list[str] | None = None) -> None:
     if args.command == "create-run":
         run_path = create_run(args.name)
         print(f"Created run: {run_path}")
+    elif args.command == "log-metric":
+        run_path = log_metric(args.run_file, args.name, args.value)
+        print(f"Updated run: {run_path}")
     else:
         print("ML Experiment Tracker")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,3 +55,35 @@ def test_create_run_prevents_nested_path_creation(tmp_path, monkeypatch):
     run_files = list(runs_dir.glob("*.json"))
     assert len(run_files) == 1
     assert "team_model_v1_best" in run_files[0].name
+
+
+def test_log_metric_adds_metrics_object_and_preserves_fields(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "baseline"])
+    run_file = list((tmp_path / "runs").glob("*.json"))[0]
+
+    main(["log-metric", "--run-file", str(run_file), "--name", "accuracy", "--value", "0.95"])
+
+    payload = json.loads(run_file.read_text(encoding="utf-8"))
+    assert payload["name"] == "baseline"
+    assert isinstance(payload["timestamp"], str)
+    assert payload["metadata"] == {}
+    assert payload["metrics"]["accuracy"] == 0.95
+    assert isinstance(payload["metrics"]["accuracy"], float)
+
+    captured = capsys.readouterr()
+    assert "Updated run:" in captured.out
+
+
+def test_log_metric_updates_existing_metric_value(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "baseline"])
+    run_file = list((tmp_path / "runs").glob("*.json"))[0]
+
+    main(["log-metric", "--run-file", str(run_file), "--name", "loss", "--value", "2.5"])
+    main(["log-metric", "--run-file", str(run_file), "--name", "loss", "--value", "1.75"])
+
+    payload = json.loads(run_file.read_text(encoding="utf-8"))
+    assert payload["metrics"]["loss"] == 1.75


### PR DESCRIPTION
### Motivation

- Provide a way to record numeric metrics into existing run JSON files via the CLI.
- Ensure metric logging preserves existing run fields (`name`, `timestamp`, `metadata`) and can create or update a `metrics` object.

### Description

- Added `log_metric(run_file: str, name: str, value: float)` which loads a run JSON, ensures a `metrics` dict exists, stores the metric value as a numeric `float`, and writes the file back.
- Added a `log-metric` subcommand to the CLI with arguments `--run-file`, `--name`, and `--value` (with `type=float`) and wired it into `main()` to call `log_metric` and print an update message.
- Added tests `test_log_metric_adds_metrics_object_and_preserves_fields` and `test_log_metric_updates_existing_metric_value` to validate numeric storage, preservation of existing fields, and metric updates.
- Closes #6

### Testing

- Ran `pytest -q` and the test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30b6b40488330848489c16d9e6473)