### PR TITLE
Reject non-finite metric values during metric logging

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -46,7 +47,11 @@ def log_metric(run_file: str, name: str, value: float) -> Path:
     if not isinstance(metrics, dict):
         metrics = {}
 
-    metrics[name] = float(value)
+    metric_value = float(value)
+    if not math.isfinite(metric_value):
+        raise ValueError(f"Metric '{name}' must be a finite number; got {metric_value!r}.")
+
+    metrics[name] = metric_value
     payload["metrics"] = metrics
 
     run_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from mltracker.cli import main
 
 
@@ -87,3 +89,17 @@ def test_log_metric_updates_existing_metric_value(tmp_path, monkeypatch):
 
     payload = json.loads(run_file.read_text(encoding="utf-8"))
     assert payload["metrics"]["loss"] == 1.75
+
+
+@pytest.mark.parametrize("bad_value", ["nan", "inf", "-inf"])
+def test_log_metric_rejects_non_finite_values(tmp_path, monkeypatch, bad_value):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "baseline"])
+    run_file = list((tmp_path / "runs").glob("*.json"))[0]
+
+    with pytest.raises(ValueError, match=r"must be a finite number"):
+        main(["log-metric", "--run-file", str(run_file), "--name", "loss", f"--value={bad_value}"])
+
+    payload = json.loads(run_file.read_text(encoding="utf-8"))
+    assert "metrics" not in payload


### PR DESCRIPTION
### Motivation
- Prevent invalid numeric values (`NaN`, `Infinity`) from being persisted as metrics which can corrupt downstream analysis. 
- Use a standard library finite check to ensure consistent, portable behavior when logging metrics.

### Description
- Import `math` and validate metric inputs with `math.isfinite` in `log_metric` before writing to the run JSON file. 
- Raise a clear `ValueError` when a metric is not finite with the message `Metric '<name>' must be a finite number; got <value>.`.
- Store the validated `float` value into the `metrics` object instead of writing raw values. 
- Add a parametrized test `test_log_metric_rejects_non_finite_values` to cover `"nan"`, `"inf"`, and `"-inf"` inputs and ensure metrics are not written on failure.

### Testing
- Ran `pytest -q` and all tests passed. 
- The new parametrized test confirms non-finite values raise `ValueError` and do not add a `metrics` key to the run payload. 
- Closes #<issue-number>

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f310aafdb483309a290446ddf5946d)