### PR TITLE
docs: document current CLI commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,46 @@ Used Codex to generate the initial project layout and tests.
 
 ### Result
 The project now has a clean `src/` structure with an initial CLI and test.
+
+
+---
+
+## Current CLI Commands
+
+Use the CLI module directly from the repository root:
+
+```bash
+PYTHONPATH=src python -m mltracker.cli <command> [options]
+```
+
+### `create-run`
+
+Creates a new run JSON file under `runs/`.
+
+**Example command**
+
+```bash
+PYTHONPATH=src python -m mltracker.cli create-run --name "baseline-model"
+```
+
+**Expected output**
+
+```text
+Created run: runs/<UTC_TIMESTAMP>_baseline-model.json
+```
+
+### `log-metric`
+
+Adds or updates a metric in an existing run JSON file.
+
+**Example command**
+
+```bash
+PYTHONPATH=src python -m mltracker.cli log-metric   --run-file "runs/<UTC_TIMESTAMP>_baseline-model.json"   --name accuracy   --value 0.91
+```
+
+**Expected output**
+
+```text
+Updated run: runs/<UTC_TIMESTAMP>_baseline-model.json
+```


### PR DESCRIPTION
### Motivation
- Make the repository README show the current CLI commands and give reproducible usage examples for `create-run` and `log-metric` so users can run the tool from source.

### Description
- Added a new `## Current CLI Commands` section to `README.md` that explains invoking the CLI from the repo root with `PYTHONPATH=src python -m mltracker.cli <command> [options]`.
- Included example commands and expected output for `create-run` and `log-metric`, and preserved all existing README content.
- Closes #7.

### Testing
- Ran the project test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3136bea208330b7aa9f3fe0ce7b16)