### PR TITLE
Add list-runs command to CLI

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -58,6 +58,28 @@ def log_metric(run_file: str, name: str, value: float) -> Path:
     return run_path
 
 
+def list_runs() -> list[str]:
+    """List run summaries from JSON files in the local runs directory."""
+    if not RUNS_DIR.exists():
+        return ["No runs found yet. Create one with: mltracker create-run --name <run-name>"]
+
+    lines: list[str] = []
+    run_files = sorted(RUNS_DIR.glob("*.json"))
+    if not run_files:
+        return ["No runs found in runs/."]
+
+    for run_file in run_files:
+        payload = json.loads(run_file.read_text(encoding="utf-8"))
+        run_name = payload.get("name", "(unnamed)")
+        timestamp = payload.get("timestamp", "(missing timestamp)")
+        metrics = payload.get("metrics")
+        metric_keys = sorted(metrics.keys()) if isinstance(metrics, dict) and metrics else []
+        metric_text = ", ".join(metric_keys) if metric_keys else "none"
+        lines.append(f"- {run_name} | {timestamp} | metrics: {metric_text}")
+
+    return lines
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
     parser = argparse.ArgumentParser(prog="mltracker")
@@ -70,6 +92,7 @@ def build_parser() -> argparse.ArgumentParser:
     log_metric_parser.add_argument("--run-file", required=True, help="Path to run JSON file")
     log_metric_parser.add_argument("--name", required=True, help="Metric name")
     log_metric_parser.add_argument("--value", required=True, type=float, help="Metric value")
+    subparsers.add_parser("list-runs", help="List tracked runs")
 
     return parser
 
@@ -85,6 +108,9 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "log-metric":
         run_path = log_metric(args.run_file, args.name, args.value)
         print(f"Updated run: {run_path}")
+    elif args.command == "list-runs":
+        for line in list_runs():
+            print(line)
     else:
         print("ML Experiment Tracker")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,3 +103,28 @@ def test_log_metric_rejects_non_finite_values(tmp_path, monkeypatch, bad_value):
 
     payload = json.loads(run_file.read_text(encoding="utf-8"))
     assert "metrics" not in payload
+
+
+def test_list_runs_handles_missing_runs_dir(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["list-runs"])
+
+    captured = capsys.readouterr()
+    assert "No runs found yet." in captured.out
+
+
+def test_list_runs_displays_run_name_timestamp_and_metric_keys(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "baseline"])
+    run_file = list((tmp_path / "runs").glob("*.json"))[0]
+    main(["log-metric", "--run-file", str(run_file), "--name", "accuracy", "--value", "0.95"])
+    main(["log-metric", "--run-file", str(run_file), "--name", "loss", "--value", "0.42"])
+
+    capsys.readouterr()
+    main(["list-runs"])
+
+    output = capsys.readouterr().out
+    assert "- baseline | " in output
+    assert "metrics: accuracy, loss" in output


### PR DESCRIPTION
### Motivation
- Provide a simple way to inspect tracked runs from the CLI by listing run name, timestamp, and available metric keys.

### Description
- Added a new `list_runs()` helper in `src/mltracker/cli.py` that reads `runs/*.json` and returns formatted lines with `name`, `timestamp`, and metric keys, and shows friendly messages when `runs/` is missing or empty.
- Wired a new `list-runs` subcommand into the CLI parser and `main()` so the summaries are printed line-by-line when invoked.
- Added tests in `tests/test_cli.py`: `test_list_runs_handles_missing_runs_dir` and `test_list_runs_displays_run_name_timestamp_and_metric_keys` to cover missing directory handling and listing output.
- Files changed: `src/mltracker/cli.py`, `tests/test_cli.py`.

Closes #8

### Testing
- Ran the full test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3161f21f48330a908bdc83e5f2c51)