### PR TITLE
Handle malformed run JSON files in list-runs

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -69,7 +69,14 @@ def list_runs() -> list[str]:
         return ["No runs found in runs/."]
 
     for run_file in run_files:
-        payload = json.loads(run_file.read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(run_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            lines.append(
+                f"WARNING: Skipping malformed run file '{run_file.name}': {exc.msg}"
+            )
+            continue
+
         run_name = payload.get("name", "(unnamed)")
         timestamp = payload.get("timestamp", "(missing timestamp)")
         metrics = payload.get("metrics")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,3 +128,35 @@ def test_list_runs_displays_run_name_timestamp_and_metric_keys(tmp_path, capsys,
     output = capsys.readouterr().out
     assert "- baseline | " in output
     assert "metrics: accuracy, loss" in output
+
+def test_list_runs_skips_malformed_json_and_shows_warning(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "valid-run"])
+    runs_dir = tmp_path / "runs"
+    malformed_file = runs_dir / "broken.json"
+    malformed_file.write_text('{"name": "oops",', encoding="utf-8")
+
+    capsys.readouterr()
+    main(["list-runs"])
+
+    output = capsys.readouterr().out
+    assert "- valid-run | " in output
+    assert "WARNING: Skipping malformed run file 'broken.json'" in output
+
+
+def test_list_runs_continues_when_multiple_malformed_files_exist(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "run-a"])
+    runs_dir = tmp_path / "runs"
+    (runs_dir / "bad1.json").write_text('{"name":', encoding="utf-8")
+    (runs_dir / "bad2.json").write_text('not-json', encoding="utf-8")
+
+    capsys.readouterr()
+    main(["list-runs"])
+
+    output = capsys.readouterr().out
+    assert "- run-a | " in output
+    assert "WARNING: Skipping malformed run file 'bad1.json'" in output
+    assert "WARNING: Skipping malformed run file 'bad2.json'" in output


### PR DESCRIPTION
### Motivation
- Listing runs should be robust to malformed JSON files in `runs/` instead of crashing the command. 
- Users should get a clear, actionable warning for files that are skipped while valid runs continue to be listed.

### Description
- Update `list_runs` to catch `json.JSONDecodeError` when reading each run file and continue processing remaining files. 
- Append a clear warning line for each skipped malformed file in the form `WARNING: Skipping malformed run file '<filename>': <message>`. 
- Add tests `test_list_runs_skips_malformed_json_and_shows_warning` and `test_list_runs_continues_when_multiple_malformed_files_exist` to cover single and multiple malformed-file scenarios. 
- Closes #<issue-number>

### Testing
- Ran `pytest -q` and all tests passed. 
- The new tests verify that valid runs are still listed and that warnings are emitted for each malformed JSON file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31a010dd48330a3a103b949a7e4d2)