### PR TITLE
Add compare-runs CLI command with metric filtering

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -87,6 +87,40 @@ def list_runs() -> list[str]:
     return lines
 
 
+def compare_runs(run_files: list[str], metric: str | None = None) -> list[str]:
+    """Compare metrics across one or more run JSON files."""
+    rows: list[tuple[str, dict[str, object]]] = []
+    all_metrics: set[str] = set()
+
+    for run_file in run_files:
+        run_path = Path(run_file)
+        payload = json.loads(run_path.read_text(encoding="utf-8"))
+        run_name = payload.get("name")
+        if not isinstance(run_name, str) or not run_name:
+            run_name = run_path.stem
+
+        metrics = payload.get("metrics")
+        metric_map = metrics if isinstance(metrics, dict) else {}
+        all_metrics.update(k for k in metric_map.keys() if isinstance(k, str))
+        rows.append((run_name, metric_map))
+
+    metric_names = [metric] if metric else sorted(all_metrics)
+    if not metric_names:
+        return ["No metrics found across the provided run files."]
+
+    lines: list[str] = []
+    for run_name, metrics in rows:
+        values: list[str] = []
+        for metric_name in metric_names:
+            if metric_name in metrics:
+                values.append(f"{metric_name}={metrics[metric_name]}")
+            else:
+                values.append(f"{metric_name}=<missing>")
+        lines.append(f"- {run_name} | " + ", ".join(values))
+
+    return lines
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
     parser = argparse.ArgumentParser(prog="mltracker")
@@ -100,6 +134,9 @@ def build_parser() -> argparse.ArgumentParser:
     log_metric_parser.add_argument("--name", required=True, help="Metric name")
     log_metric_parser.add_argument("--value", required=True, type=float, help="Metric value")
     subparsers.add_parser("list-runs", help="List tracked runs")
+    compare_runs_parser = subparsers.add_parser("compare-runs", help="Compare metrics across runs")
+    compare_runs_parser.add_argument("run_files", nargs="+", help="Run JSON files to compare")
+    compare_runs_parser.add_argument("--metric", help="Metric to compare")
 
     return parser
 
@@ -117,6 +154,9 @@ def main(argv: list[str] | None = None) -> None:
         print(f"Updated run: {run_path}")
     elif args.command == "list-runs":
         for line in list_runs():
+            print(line)
+    elif args.command == "compare-runs":
+        for line in compare_runs(args.run_files, args.metric):
             print(line)
     else:
         print("ML Experiment Tracker")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,3 +160,41 @@ def test_list_runs_continues_when_multiple_malformed_files_exist(tmp_path, capsy
     assert "- run-a | " in output
     assert "WARNING: Skipping malformed run file 'bad1.json'" in output
     assert "WARNING: Skipping malformed run file 'bad2.json'" in output
+
+
+def test_compare_runs_with_all_metrics_when_metric_not_provided(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "run-a"])
+    run_a = list((tmp_path / "runs").glob("*.json"))[0]
+    main(["log-metric", "--run-file", str(run_a), "--name", "accuracy", "--value", "0.9"])
+
+    main(["create-run", "--name", "run-b"])
+    run_b = sorted((tmp_path / "runs").glob("*.json"))[-1]
+    main(["log-metric", "--run-file", str(run_b), "--name", "loss", "--value", "0.2"])
+
+    capsys.readouterr()
+    main(["compare-runs", str(run_a), str(run_b)])
+
+    output = capsys.readouterr().out
+    assert "- run-a | accuracy=0.9, loss=<missing>" in output
+    assert "- run-b | accuracy=<missing>, loss=0.2" in output
+
+
+def test_compare_runs_with_specific_metric_only(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "run-a"])
+    run_a = list((tmp_path / "runs").glob("*.json"))[0]
+    main(["log-metric", "--run-file", str(run_a), "--name", "accuracy", "--value", "0.9"])
+
+    main(["create-run", "--name", "run-b"])
+    run_b = sorted((tmp_path / "runs").glob("*.json"))[-1]
+
+    capsys.readouterr()
+    main(["compare-runs", str(run_a), str(run_b), "--metric", "accuracy"])
+
+    output = capsys.readouterr().out
+    assert "- run-a | accuracy=0.9" in output
+    assert "- run-b | accuracy=<missing>" in output
+    assert "loss=" not in output


### PR DESCRIPTION
### Motivation
- Provide a way to compare metrics from multiple run JSON files from the CLI via a dedicated command `compare-runs`.
- Allow aggregating all discovered metric keys across runs or focusing on a single metric via `--metric` and clearly indicate missing values.

### Description
- Added a new function `compare_runs(run_files, metric)` to `src/mltracker/cli.py` that loads each run JSON, collects metric keys, and returns per-run comparison lines with missing metrics shown as `<missing>`.
- Extended the CLI parser in `build_parser()` with a `compare-runs` subcommand that accepts positional `run_files` and an optional `--metric` argument, and wired the command into `main()` to print the comparison output.
- Added unit tests in `tests/test_cli.py` covering comparison across all metrics when `--metric` is omitted and comparison limited to a specific metric, including assertions around `<missing>` handling.

### Testing
- Ran the test suite with `pytest -q`, and all tests passed successfully.
- The modified files exercised by tests were `src/mltracker/cli.py` and `tests/test_cli.py` and the new tests validated both multi-metric and single-metric comparison behavior.

Closes #9

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31d0216a483309c0f3ffc2ce08aac)