### PR TITLE
Handle malformed JSON in compare-runs

### DIFF
--- a/src/mltracker/cli.py
+++ b/src/mltracker/cli.py
@@ -89,12 +89,20 @@ def list_runs() -> list[str]:
 
 def compare_runs(run_files: list[str], metric: str | None = None) -> list[str]:
     """Compare metrics across one or more run JSON files."""
+    lines: list[str] = []
     rows: list[tuple[str, dict[str, object]]] = []
     all_metrics: set[str] = set()
 
     for run_file in run_files:
         run_path = Path(run_file)
-        payload = json.loads(run_path.read_text(encoding="utf-8"))
+        try:
+            payload = json.loads(run_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            lines.append(
+                f"WARNING: Skipping malformed run file '{run_path.name}': {exc.msg}"
+            )
+            continue
+
         run_name = payload.get("name")
         if not isinstance(run_name, str) or not run_name:
             run_name = run_path.stem
@@ -106,9 +114,9 @@ def compare_runs(run_files: list[str], metric: str | None = None) -> list[str]:
 
     metric_names = [metric] if metric else sorted(all_metrics)
     if not metric_names:
-        return ["No metrics found across the provided run files."]
+        lines.append("No metrics found across the provided run files.")
+        return lines
 
-    lines: list[str] = []
     for run_name, metrics in rows:
         values: list[str] = []
         for metric_name in metric_names:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,3 +198,40 @@ def test_compare_runs_with_specific_metric_only(tmp_path, capsys, monkeypatch):
     assert "- run-a | accuracy=0.9" in output
     assert "- run-b | accuracy=<missing>" in output
     assert "loss=" not in output
+
+
+def test_compare_runs_skips_malformed_json_and_shows_warning(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "valid-run"])
+    valid_run = list((tmp_path / "runs").glob("*.json"))[0]
+    main(["log-metric", "--run-file", str(valid_run), "--name", "accuracy", "--value", "0.88"])
+    malformed_run = tmp_path / "runs" / "broken.json"
+    malformed_run.write_text('{"name":"bad",', encoding="utf-8")
+
+    capsys.readouterr()
+    main(["compare-runs", str(valid_run), str(malformed_run)])
+
+    output = capsys.readouterr().out
+    assert "- valid-run | accuracy=0.88" in output
+    assert "WARNING: Skipping malformed run file 'broken.json'" in output
+
+
+def test_compare_runs_continues_with_multiple_malformed_files(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    main(["create-run", "--name", "run-a"])
+    run_a = list((tmp_path / "runs").glob("*.json"))[0]
+    main(["log-metric", "--run-file", str(run_a), "--name", "accuracy", "--value", "0.9"])
+
+    runs_dir = tmp_path / "runs"
+    (runs_dir / "bad1.json").write_text("{", encoding="utf-8")
+    (runs_dir / "bad2.json").write_text("not-json", encoding="utf-8")
+
+    capsys.readouterr()
+    main(["compare-runs", str(run_a), str(runs_dir / "bad1.json"), str(runs_dir / "bad2.json")])
+
+    output = capsys.readouterr().out
+    assert "- run-a | accuracy=0.9" in output
+    assert "WARNING: Skipping malformed run file 'bad1.json'" in output
+    assert "WARNING: Skipping malformed run file 'bad2.json'" in output


### PR DESCRIPTION
### Motivation
- `compare-runs` would crash when one of the provided run JSON files was malformed instead of continuing to process the other files.
- `list-runs` already handled malformed run files gracefully by warning and skipping them, so `compare-runs` should match that robustness.
- The change aims to present clear warnings for skipped files and still compare valid runs so the CLI is more resilient.

### Description
- Wrap `json.loads` in `compare_runs` with a `try/except json.JSONDecodeError` to catch malformed files on a per-file basis and `continue` processing remaining files.
- Append warnings to the `lines` output using the same format as `list_runs` (`WARNING: Skipping malformed run file '<name>': <msg>`), and preserve returning any comparison lines for valid runs.
- Ensure the "no metrics" case appends the message to `lines` and returns it consistently.
- Added tests `test_compare_runs_skips_malformed_json_and_shows_warning` and `test_compare_runs_continues_with_multiple_malformed_files` in `tests/test_cli.py` to cover single and multiple malformed-file scenarios.

### Testing
- Ran `pytest -q` and all tests passed successfully.
- New tests `test_compare_runs_skips_malformed_json_and_shows_warning` and `test_compare_runs_continues_with_multiple_malformed_files` were executed as part of the test suite and passed.

Closes #<issue-number>

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3214519e08330b1274c9383278569)