### PR TITLE
docs: add full experiment tracker usage workflow to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,74 @@ PYTHONPATH=src python -m mltracker.cli log-metric   --run-file "runs/<UTC_TIMEST
 ```text
 Updated run: runs/<UTC_TIMESTAMP>_baseline-model.json
 ```
+
+## Usage
+
+Follow this end-to-end workflow to track and compare experiments.
+
+### 1) Create a run
+
+```bash
+mltracker create-run --name baseline
+```
+
+Example output:
+
+```text
+Created run: runs/20260430T120000Z_baseline.json
+```
+
+### 2) Log metrics
+
+```bash
+mltracker log-metric --run-file runs/<file>.json --name accuracy --value 0.95
+```
+
+Example output:
+
+```text
+Updated run: runs/20260430T120000Z_baseline.json
+```
+
+### 3) List runs
+
+```bash
+mltracker list-runs
+```
+
+Example output:
+
+```text
+runs/20260430T120000Z_baseline.json
+runs/20260430T121500Z_tuned.json
+```
+
+### 4) Compare runs
+
+```bash
+mltracker compare-runs runs/<file1>.json runs/<file2>.json
+```
+
+Example output:
+
+```text
+Comparing runs:
+- runs/20260430T120000Z_baseline.json
+- runs/20260430T121500Z_tuned.json
+
+Metrics:
+accuracy: 0.95 vs 0.97
+loss: 0.42 vs 0.36
+```
+
+```bash
+mltracker compare-runs runs/<file1>.json runs/<file2>.json --metric accuracy
+```
+
+Example output:
+
+```text
+Comparing metric: accuracy
+runs/20260430T120000Z_baseline.json: 0.95
+runs/20260430T121500Z_tuned.json: 0.97
+```


### PR DESCRIPTION
### Motivation

- Provide a clear end-to-end example of the CLI experiment-tracking workflow so users can quickly create runs, log metrics, list runs, and compare runs.

### Description

- Added a new `## Usage` section to `README.md` that documents the step-by-step workflow with code blocks for the commands `mltracker create-run`, `mltracker log-metric`, `mltracker list-runs`, and `mltracker compare-runs`.
- Included example output blocks for each step, including both variants of `compare-runs` (full comparison and `--metric` filter).
- Kept all existing README content intact and committed the change to the repository.
- The PR description includes `Closes #10` to link and close the related issue.

### Testing

- Committed the updated `README.md` with `git commit`, which succeeded and reported `1 file changed`.
- Verified the repository status with `git status --short` and inspected the updated file with `nl -ba README.md | sed -n '1,260p'`, both commands completed successfully.
- No unit tests were added or modified for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32342cc0083308ae7ec9ea2aa66e1)