### PR TITLE
docs: align README usage examples with current CLI invocation/output

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Follow this end-to-end workflow to track and compare experiments.
 ### 1) Create a run
 
 ```bash
-mltracker create-run --name baseline
+PYTHONPATH=src python -m mltracker.cli create-run --name baseline
 ```
 
 Example output:
@@ -129,7 +129,7 @@ Created run: runs/20260430T120000Z_baseline.json
 ### 2) Log metrics
 
 ```bash
-mltracker log-metric --run-file runs/<file>.json --name accuracy --value 0.95
+PYTHONPATH=src python -m mltracker.cli log-metric --run-file runs/<file>.json --name accuracy --value 0.95
 ```
 
 Example output:
@@ -141,42 +141,36 @@ Updated run: runs/20260430T120000Z_baseline.json
 ### 3) List runs
 
 ```bash
-mltracker list-runs
+PYTHONPATH=src python -m mltracker.cli list-runs
 ```
 
 Example output:
 
 ```text
-runs/20260430T120000Z_baseline.json
-runs/20260430T121500Z_tuned.json
+- baseline | 2026-04-30T12:00:00+00:00 | metrics: accuracy, loss
+- tuned | 2026-04-30T12:15:00+00:00 | metrics: accuracy, loss
 ```
 
 ### 4) Compare runs
 
 ```bash
-mltracker compare-runs runs/<file1>.json runs/<file2>.json
+PYTHONPATH=src python -m mltracker.cli compare-runs runs/<file1>.json runs/<file2>.json
 ```
 
 Example output:
 
 ```text
-Comparing runs:
-- runs/20260430T120000Z_baseline.json
-- runs/20260430T121500Z_tuned.json
-
-Metrics:
-accuracy: 0.95 vs 0.97
-loss: 0.42 vs 0.36
+- baseline | accuracy=0.95, loss=0.42
+- tuned | accuracy=0.97, loss=0.36
 ```
 
 ```bash
-mltracker compare-runs runs/<file1>.json runs/<file2>.json --metric accuracy
+PYTHONPATH=src python -m mltracker.cli compare-runs runs/<file1>.json runs/<file2>.json --metric accuracy
 ```
 
 Example output:
 
 ```text
-Comparing metric: accuracy
-runs/20260430T120000Z_baseline.json: 0.95
-runs/20260430T121500Z_tuned.json: 0.97
+- baseline | accuracy=0.95
+- tuned | accuracy=0.97
 ```


### PR DESCRIPTION
### Motivation
- The README previously showed examples using a global `mltracker` command and older output formats that no longer match the code in `src/mltracker/cli.py`.
- Updating examples ensures the documentation reflects the actual invocation and printed output produced by the CLI helpers.

### Description
- Replaced `mltracker ...` command examples with the current invocation `PYTHONPATH=src python -m mltracker.cli ...` for create, log, list, and compare examples.
- Updated the `list-runs` example output to the `- <name> | <timestamp> | metrics: ...` line format produced by `list_runs()`.
- Updated both `compare-runs` example outputs to the `- <name> | metric=value` format produced by `compare_runs()` for both the full comparison and the `--metric` case.
- This change is documentation-only and does not modify any code files; Closes #<issue-number>.

### Testing
- Verified README edits with quick automated content checks using `rg` and `sed` to confirm the new command forms and example outputs were applied, and these checks succeeded.
- No unit tests were modified or executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3264614e88330bb897a8b497b37c9)