### PR TITLE
Make package installable, add console script, update CI and README

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,9 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install -e . --no-build-isolation
           pip install pytest
 
       - name: Run tests
-        env:
-          PYTHONPATH: src
         run: pytest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,9 +19,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . --no-build-isolation
+          python -m pip install --upgrade pip setuptools wheel
           pip install pytest
+          python -m pip install -e . --no-build-isolation
 
       - name: Run tests
         run: pytest

--- a/README.md
+++ b/README.md
@@ -70,12 +70,19 @@ The project now has a clean `src/` structure with an initial CLI and test.
 
 ---
 
-## Current CLI Commands
-
-Use the CLI module directly from the repository root:
+## Installation
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli <command> [options]
+pip install -e .
+```
+
+## Current CLI Commands
+
+Install the package first, then run the CLI:
+
+```bash
+pip install -e .
+mltracker <command> [options]
 ```
 
 ### `create-run`
@@ -85,7 +92,7 @@ Creates a new run JSON file under `runs/`.
 **Example command**
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli create-run --name "baseline-model"
+mltracker create-run --name "baseline-model"
 ```
 
 **Expected output**
@@ -101,7 +108,7 @@ Adds or updates a metric in an existing run JSON file.
 **Example command**
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli log-metric   --run-file "runs/<UTC_TIMESTAMP>_baseline-model.json"   --name accuracy   --value 0.91
+mltracker log-metric   --run-file "runs/<UTC_TIMESTAMP>_baseline-model.json"   --name accuracy   --value 0.91
 ```
 
 **Expected output**
@@ -117,7 +124,7 @@ Follow this end-to-end workflow to track and compare experiments.
 ### 1) Create a run
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli create-run --name baseline
+mltracker create-run --name baseline
 ```
 
 Example output:
@@ -129,7 +136,7 @@ Created run: runs/20260430T120000Z_baseline.json
 ### 2) Log metrics
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli log-metric --run-file runs/<file>.json --name accuracy --value 0.95
+mltracker log-metric --run-file runs/<file>.json --name accuracy --value 0.95
 ```
 
 Example output:
@@ -141,7 +148,7 @@ Updated run: runs/20260430T120000Z_baseline.json
 ### 3) List runs
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli list-runs
+mltracker list-runs
 ```
 
 Example output:
@@ -154,7 +161,7 @@ Example output:
 ### 4) Compare runs
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli compare-runs runs/<file1>.json runs/<file2>.json
+mltracker compare-runs runs/<file1>.json runs/<file2>.json
 ```
 
 Example output:
@@ -165,7 +172,7 @@ Example output:
 ```
 
 ```bash
-PYTHONPATH=src python -m mltracker.cli compare-runs runs/<file1>.json runs/<file2>.json --metric accuracy
+mltracker compare-runs runs/<file1>.json runs/<file2>.json --metric accuracy
 ```
 
 Example output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "ml-experiment-tracker"
 version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,17 @@
-[build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "ml-experiment-tracker"
 version = "0.1.0"
 description = "ML Experiment Tracker"
 requires-python = ">=3.9"
+
+[project.scripts]
+mltracker = "mltracker.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]


### PR DESCRIPTION
### Motivation

- Allow the project to be installed and run as a normal Python package from the repository and to avoid relying on `PYTHONPATH` in CI and docs.
- Expose the CLI as an installable console script to simplify usage and examples in the README.

### Description

- Add an editable installation step to the GitHub Actions workflow by running `python -m pip install -e . --no-build-isolation` and remove the `PYTHONPATH` environment injection for the test step.
- Add `project.scripts` entry `mltracker = "mltracker.cli:main"` and setuptools `package-dir`/`packages.find` configuration to `pyproject.toml` so the package can be installed from `src` and provide the `mltracker` console script.
- Update `README.md` to include installation instructions (`pip install -e .`) and replace `PYTHONPATH=src python -m mltracker.cli` examples with the `mltracker` command.

### Testing

- Run `pytest` as configured in CI and in local development, which executes the existing test suite (e.g. `tests/test_cli.py`), and the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f329532c088330988fe7c5e48a79c8)